### PR TITLE
Extract modifyValidator

### DIFF
--- a/valchemy.js
+++ b/valchemy.js
@@ -5,25 +5,23 @@ function BasicValidation() {
   this.messages = [];
 }
 
-function addValidator(validatorBuilder) {
+function addValidator(makeValidator) {
   return function() {
-    this.validators.push(validatorBuilder.apply(this, arguments));
+    var validator = makeValidator.apply(this, arguments);
+    this.validators.push(validator);
     return this;
   }
 }
 
-function modifyValidator(validatorTransform) {
+function modifyValidator(makeModifier) {
   return function() {
-    var normalizedTransform = validatorTransform.apply(this, arguments);
-    if(normalizedTransform.length != 2)
-      throw "Invalid validator modifier! Must have 2 arguments (validator, value).";
+    var modifier = makeModifier.apply(this, arguments).bind(this);
 
     var targetValidator = this.validators.pop();
-    var transformedValidator = function(value) {
-      return normalizedTransform.apply(this, [targetValidator, value]);
-    }.bind(this);
+    this.validators.push(function(value) {
+      return modifier(targetValidator, value);
+    });
 
-    this.validators.push(transformedValidator);
     return this;
   }
 }


### PR DESCRIPTION
This may be premature, and I'm not entirely convinced it's a good idea,
but I thought it'd make for an interesting conversation piece.

The process of validation so far consists of two phases: 1) building up
the validation object, and 2) calling validate() with the value.

The first phase consists of chainable methods, which used to just append
validator functions into the validation's validators array. We have the
addValidator() function that captures that process.

Now, we have a new operation which instead of appending a new validator,
transforms the last validator in the list. We could, as with
addValidator(), extract the logic for transforming the last validator
into an agnostic function, which this commit does with
modifyValidator().

The structure this suggests is that we could have two directories, maybe
'validatorBuilders' and 'validatorModifiers', where each module contains
a function that captures only the relevant logic for that particular
validator or modifier. Then, in valchemy.js, we feed each module through
the relevant function, addValidator() or modifyValidator(), as we add it
to the prototype.

For validationBuilders, the interface I have in mind is:

````javascript
function(/* any number of arguments */) {
  return function(value) {
    /* logic */
    return result;
  };
}
````

And for validationModifiers:

````javascript
function(/* any number of arguments */) {
  return function(originalValidator, value) {
    var newValidator = /* some composition of originalValidator */
    return newValidator(value);
  };
}
````