### PR TITLE
Add default error messages

### DIFF
--- a/spec/usage/usageExampleSpec.js
+++ b/spec/usage/usageExampleSpec.js
@@ -3,10 +3,13 @@ var v = require('../../valchemy.js');
 describe('Use Case #1: Validating a name for letters only pattern and length ', function() {
   it('invalidates', function() {
     var basicValidation = new v.BasicValidation()
-      .length(10).withMessage("The name must be 10 characters long")
-      .pattern(/[a-zA-Z]+/);
+      .length(10)
+      .pattern(/^[a-zA-Z]+$/)
+        .withMessage('Name must consist only of uppercase and lowercase letters.');
 
-    expect(basicValidation.validate('Matt Rothenberg192').valid).toBeFalsy();
-    expect(basicValidation.validate('Matt Rothenberg192').messages).toContain("The name must be 10 characters long");
+    var result = basicValidation.validate('Matt Rothenberg192');
+    expect(result.valid).toBeFalsy();
+    expect(result.messages).toContain('Must be exactly 10 characters.');
+    expect(result.messages).toContain('Name must consist only of uppercase and lowercase letters.');
   });
 });

--- a/spec/validators/lengthSpec.js
+++ b/spec/validators/lengthSpec.js
@@ -2,11 +2,19 @@ var lengthValidator = require('../../validators/length');
 
 describe('length validator', function() {
   beforeEach(function() {
-    this.doesValidate = function() {
+    this.validationResult = function() {
       var validator = lengthValidator(this.allowedLength);
       var valueToValidate = this.value;
       var result = validator(valueToValidate);
-      return result.valid;
+      return result;
+    }
+
+    this.doesValidate = function() {
+      return this.validationResult().valid;
+    }
+
+    this.message = function() {
+      return this.validationResult().message;
     }
   });
 
@@ -18,6 +26,7 @@ describe('length validator', function() {
 
     it('invalidates', function() {
       expect(this.doesValidate()).toBeFalsy();
+      expect(this.message()).toEqual('Must be exactly 9 characters.');
     });
   });
 
@@ -29,6 +38,7 @@ describe('length validator', function() {
 
     it('invalidates', function() {
       expect(this.doesValidate()).toBeFalsy();
+      expect(this.message()).toEqual('Must be exactly 10 characters.');
     });
   });
 
@@ -40,6 +50,7 @@ describe('length validator', function() {
 
     it('validates', function() {
       expect(this.doesValidate()).toBeTruthy();
+      expect(this.message()).toBeNull();
     });
   });
 
@@ -51,6 +62,7 @@ describe('length validator', function() {
 
     it('invalidates', function() {
       expect(this.doesValidate()).toBeFalsy();
+      expect(this.message()).toEqual('Must be exactly 10 characters.');
     });
   });
 
@@ -62,6 +74,7 @@ describe('length validator', function() {
 
     it('invalidates', function() {
       expect(this.doesValidate()).toBeFalsy();
+      expect(this.message()).toEqual('Must be exactly 10 characters.');
     });
   });
 

--- a/spec/validators/patternSpec.js
+++ b/spec/validators/patternSpec.js
@@ -2,11 +2,19 @@ var patternValidator = require('../../validators/pattern');
 
 describe('pattern validator', function() {
   beforeEach(function() {
-    this.doesValidate = function() {
+    this.validationResult = function() {
       var validator = patternValidator(this.pattern);
       var valueToValidate = this.value;
       var result = validator(valueToValidate);
-      return result.valid;
+      return result;
+    }
+
+    this.doesValidate = function() {
+      return this.validationResult().valid;
+    }
+
+    this.message = function() {
+      return this.validationResult().message;
     }
   });
 
@@ -18,6 +26,7 @@ describe('pattern validator', function() {
 
     it('invalidates', function() {
       expect(this.doesValidate()).toBeFalsy();
+      expect(this.message()).toEqual('Must match pattern /^\\d{3}$/.');
     });
   });
 
@@ -29,6 +38,7 @@ describe('pattern validator', function() {
 
     it('validates', function() {
       expect(this.doesValidate()).toBeTruthy();
+      expect(this.message()).toBeNull();
     });
   });
 

--- a/validators/length.js
+++ b/validators/length.js
@@ -1,7 +1,10 @@
 module.exports = function(requiredLength) {
   return function(value) {
+    var valid = value != null && value.length === requiredLength;
+
     return {
-      valid: value != null && value.length === requiredLength
+      valid: valid,
+      message: valid ? null : 'Must be exactly ' + requiredLength + ' characters.'
     }
   }
 };

--- a/validators/pattern.js
+++ b/validators/pattern.js
@@ -1,8 +1,11 @@
 module.exports = function(pattern) {
   return function(value) {
     if (value === null || value === undefined) { value = ''; }
+    var valid = !! value.match(pattern);
+
     return {
-      valid: !! value.match(pattern)
+      valid: valid,
+      message: valid ? null : 'Must match pattern ' + pattern + '.'
     };
   };
 };


### PR DESCRIPTION
Resolves issue #3

The length and pattern validators now provide a default message on
failure. Awesomely, this required zero changes to the core logic in
valchemy.js