### PR TITLE
Create Result object for validators to return

### DIFF
--- a/modifiers/forAttribute.js
+++ b/modifiers/forAttribute.js
@@ -1,11 +1,12 @@
+var Result = require('../results/result');
+
 module.exports = function(attribute) {
   return function(validator) {
     return function(obj) {
-      var res = validator(obj[attribute]);
-      if (!res.valid) {
-        res.forAttribute = attribute;
-      }
-      return res;
+      var result = validator(obj[attribute]);
+      return result.isValid() ?
+        result :
+        Result.clone(result, {forAttribute: attribute});
     }
   }
 };

--- a/modifiers/ifPresent.js
+++ b/modifiers/ifPresent.js
@@ -1,14 +1,10 @@
+var valid = require('../results/valid');
+
 module.exports = function() {
   return function(validator) {
     return function(value) {
-      if (value === '' || value === undefined || value === null) {
-        return {
-          valid: true,
-          message: null
-        };
-      } else {
-        return validator(value);
-      }
+      return (value === '' || value === undefined || value === null) ?
+        valid() : validator(value);
     }
   };
 };

--- a/modifiers/onlyIf.js
+++ b/modifiers/onlyIf.js
@@ -1,15 +1,10 @@
+var valid = require('../results/valid');
+
 module.exports = function(condition) {
   return function(validator) {
     return function(value) {
       if( typeof(condition) == 'function') condition = condition();
-      if(condition) {
-        return validator(value);
-      } else {
-        return {
-          valid: true,
-          message: null
-        }
-      }
+      return condition ? validator(value) : valid();
     }
   }
 }

--- a/modifiers/withMessage.js
+++ b/modifiers/withMessage.js
@@ -1,9 +1,12 @@
+var Result = require('../results/result');
+
 module.exports = function(message) {
   return function(validator) {
     return function(value) {
       var result = validator(value);
-      if ( ! result.valid ) { result.message = message };
-      return result;
+      return result.isValid() ?
+        result :
+        Result.clone(result, {errors: [message]});
     }
   };
 };

--- a/results/invalid.js
+++ b/results/invalid.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+var Result = require('./result.js');
+
+module.exports = function invalid(message, forAttribute) {
+  return new Result(false, {errors: [message], forAttribute: forAttribute});
+};
+

--- a/results/result.js
+++ b/results/result.js
@@ -1,0 +1,37 @@
+var _ = require('lodash');
+
+function Result(validity, options) {
+  this.valid = validity;
+  this.forAttribute = options.forAttribute;
+  this.errors = options.errors || [];
+  this.attributeErrors = options.attributeErrors || null;
+}
+
+Result.clone = function(result, overrides) {
+  return new Result(
+    result.isValid(),
+    _.assign(optionsFor(result), overrides)
+  );
+}
+
+function optionsFor(result) {
+  return {
+    forAttribute: result.forAttribute,
+    errors: result.errors,
+    attributeErrors: result.attributeErrors
+  };
+}
+
+Result.prototype.isValid = function() {
+  return this.valid;
+};
+
+Result.prototype.isBaseError = function() {
+  return !this.isAttributeError();
+};
+
+Result.prototype.isAttributeError = function() {
+  return !!this.forAttribute;
+};
+
+module.exports = Result;

--- a/results/valid.js
+++ b/results/valid.js
@@ -1,0 +1,5 @@
+var Result = require('./result.js');
+
+module.exports = function valid(options) {
+  return new Result(true, options || {});
+};

--- a/spec/BasicValidationSpec.js
+++ b/spec/BasicValidationSpec.js
@@ -1,4 +1,6 @@
 var v = require('../valchemy.js');
+var valid = require('../results/valid');
+var invalid = require('../results/invalid');
 
 describe('basic validation', function() {
   describe('with multiple validators', function() {
@@ -8,7 +10,7 @@ describe('basic validation', function() {
           .length(this.allowedLength)
           .pattern(this.pattern)
           .validate(this.value)
-          .valid;
+          .isValid();
       }
     });
 
@@ -54,31 +56,27 @@ describe('basic validation', function() {
       var basicValidation = new v.BasicValidation()
           .length(10).withMessage('The name must be 10 characters long');
 
-      expect(basicValidation.validate('Matt Rothenberg192').messages).toContain("The name must be 10 characters long");
+      expect(basicValidation.validate('Matt Rothenberg192').errors).toContain("The name must be 10 characters long");
     })
 
     it('does not provide the given message on validaton', function() {
       var basicValidation = new v.BasicValidation()
         .length(10).withMessage("The name must be 10 characters long");
       expect(basicValidation.validate('Elizabethe').valid).toBeTruthy();
-      expect(basicValidation.validate('Elizabethe').messages).not.toContain("The name must be 10 characters long");
+      expect(basicValidation.validate('Elizabethe').errors).not.toContain("The name must be 10 characters long");
     });
   });
 
   describe('when some of the results have a forAttribute key', function() {
     it('includes only the messages of the results without forAttribute keys in "messages"', function() {
       var baconValidator = function(value) {
-        if(value === 'bacon')
-          return { valid: true, message: null };
-        else
-          return { valid: false, message: 'Why is this not bacon' };
+        return (value === 'bacon') ?
+          valid() : invalid('Why is this not bacon');
       };
 
       var threeSquareMealsValidator = function(value) {
-        if(Object.keys(value).length >= 3)
-          return { valid: true, message: null };
-        else
-          return { valid: false, message: 'I need three square meals a day!' };
+        return (Object.keys(value).length >= 3) ?
+          valid() : invalid('I need three square meals a day!');
       }
 
       var menu = { breakfast: 'bacon', lunch: 'salad' };
@@ -89,22 +87,18 @@ describe('basic validation', function() {
                               .custom(baconValidator).forAttribute('dinner')
                               .custom(threeSquareMealsValidator);
 
-      expect(validation.validate(menu).messages).toEqual(['I need three square meals a day!']);
+      expect(validation.validate(menu).errors).toEqual(['I need three square meals a day!']);
     });
 
     it('includes the messages of the results with forAttribute keys in an "attributeMessages" object', function() {
       var baconValidator = function(value) {
-        if(value === 'bacon')
-          return { valid: true, message: null };
-        else
-          return { valid: false, message: 'Why is this not bacon' };
+        return (value === 'bacon') ?
+          valid() : invalid('Why is this not bacon');
       };
 
       var threeSquareMealsValidator = function(value) {
-        if(Object.keys(value).length >= 3)
-          return { valid: true, message: null };
-        else
-          return { valid: false, message: 'I need three square meals a day!' };
+        return (Object.keys(value).length >= 3) ?
+          valid() : invalid('I need three square meals a day!');
       }
 
       var menu = { breakfast: 'bacon', lunch: 'salad' };
@@ -115,25 +109,21 @@ describe('basic validation', function() {
                               .custom(baconValidator).forAttribute('dinner')
                               .custom(threeSquareMealsValidator);
 
-      expect(validation.validate(menu).attributeMessages).toEqual({
-        lunch: 'Why is this not bacon',
-        dinner: 'Why is this not bacon'
+      expect(validation.validate(menu).attributeErrors).toEqual({
+        lunch: ['Why is this not bacon'],
+        dinner: ['Why is this not bacon']
       });
     });
 
     it('returns an empty attributeMessages object when none of the results have a forAttribute key', function() {
       var baconValidator = function(value) {
-        if(value === 'bacon')
-          return { valid: true, message: null };
-        else
-          return { valid: false, message: 'Why is this not bacon' };
+        return (value === 'bacon') ?
+          valid() : invalid('Why is this not bacon');
       };
 
       var threeSquareMealsValidator = function(value) {
-        if(Object.keys(value).length >= 3)
-          return { valid: true, message: null };
-        else
-          return { valid: false, message: 'I need three square meals a day!' };
+        return (Object.keys(value).length >= 3) ?
+          valid() : invalid('I need three square meals a day!');
       }
 
       var menu = { breakfast: 'bacon', lunch: 'salad' };
@@ -142,7 +132,7 @@ describe('basic validation', function() {
                               .custom(baconValidator)
                               .custom(threeSquareMealsValidator);
 
-      expect(validation.validate(menu).attributeMessages).toEqual(null);
+      expect(validation.validate(menu).attributeErrors).toEqual(null);
     });
 
   });

--- a/spec/modifiers/forAttributeSpec.js
+++ b/spec/modifiers/forAttributeSpec.js
@@ -1,8 +1,10 @@
+var valid = require('../../results/valid');
+var invalid = require('../../results/invalid');
+
 function baconValidator(value) {
-  if(value === 'bacon')
-    return { valid: true, message: null };
-  else
-    return { valid: false, message: 'Why is this not bacon' };
+  return (value === 'bacon') ?
+    valid() :
+    invalid('Why is this not bacon');
 }
 
 describe('forAttribute modifier', function() {
@@ -18,8 +20,8 @@ describe('forAttribute modifier', function() {
       lunch: 'salad',
     };
 
-    expect(baconForBreakfastValidator(menu).valid).toBeTruthy();
-    expect(baconForBreakfastValidator(menu).message).toBeNull();
+    expect(baconForBreakfastValidator(menu).isValid()).toBeTruthy();
+    expect(baconForBreakfastValidator(menu).errors).toEqual([]);
   });
 
   it('is invalid when the value of the given attribute fails the original validator', function() {
@@ -33,8 +35,8 @@ describe('forAttribute modifier', function() {
       lunch: 'salad',
     };
 
-    expect(baconForLunchValidator(menu).valid).toBeFalsy();
-    expect(baconForLunchValidator(menu).message).toEqual('Why is this not bacon');
+    expect(baconForLunchValidator(menu).isValid()).toBeFalsy();
+    expect(baconForLunchValidator(menu).errors).toEqual(['Why is this not bacon']);
   });
 
   it('includes the name of the attribute in the result when invalid', function() {

--- a/spec/modifiers/ifPresentSpec.js
+++ b/spec/modifiers/ifPresentSpec.js
@@ -1,12 +1,11 @@
 var ifPresentFactory = require('../../modifiers/ifPresent');
+var invalid = require('../../results/invalid.js');
+var valid = require('../../results/valid.js');
 
 describe('withMessage modifier', function() {
   var alwaysInvalidValidator = jasmine.createSpy('alwaysInvalidValidator')
     .and.callFake(function(value) {
-      return {
-        valid: false,
-        message: "ABSOLUTELY NOT"
-      };
+      return invalid('ABSOLUTELY NOT');
     });
 
   var ifPresentModifier = ifPresentFactory();
@@ -16,19 +15,15 @@ describe('withMessage modifier', function() {
 
   describe('when the value is not blank', function() {
     it('returns the result of the original validation', function() {
-      expect(optionalAlwaysInvalidValidator('notblank')).toEqual({
-        valid: false,
-        message: "ABSOLUTELY NOT"
-      });
+      expect(optionalAlwaysInvalidValidator('notblank')).toEqual(
+        invalid('ABSOLUTELY NOT')
+      );
     });
   });
 
   describe('when the value is empty string', function() {
     it('returns valid', function() {
-      expect(optionalAlwaysInvalidValidator('')).toEqual({
-        valid: true,
-        message: null
-      });
+      expect(optionalAlwaysInvalidValidator('')).toEqual(valid());
     });
 
     it('does not execute the original validator at all', function() {
@@ -39,10 +34,7 @@ describe('withMessage modifier', function() {
 
   describe('when the value is null', function() {
     it('returns valid', function() {
-      expect(optionalAlwaysInvalidValidator(null)).toEqual({
-        valid: true,
-        message: null
-      });
+      expect(optionalAlwaysInvalidValidator(null)).toEqual(valid());
     });
 
     it('does not execute the original validator at all', function() {
@@ -53,10 +45,7 @@ describe('withMessage modifier', function() {
 
   describe('when the value is undefined', function() {
     it('returns valid', function() {
-      expect(optionalAlwaysInvalidValidator(undefined)).toEqual({
-        valid: true,
-        message: null
-      });
+      expect(optionalAlwaysInvalidValidator(undefined)).toEqual(valid());
     });
 
     it('does not execute the original validator at all', function() {

--- a/spec/modifiers/onlyIfSpec.js
+++ b/spec/modifiers/onlyIfSpec.js
@@ -1,4 +1,6 @@
 var onlyIfModifierFactory = require('../../modifiers/onlyIf');
+var invalid = require('../../results/invalid');
+var valid = require('../../results/valid');
 
 describe('ifOnly modifier', function() {
   it("is always valid when the condition is false", function() {
@@ -6,18 +8,12 @@ describe('ifOnly modifier', function() {
     var ourModifier = onlyIfModifierFactory(false);
 
     var customValidator = function(value) {
-      return {
-        valid: false,
-        message: null
-      }
+      return invalid('nope');
     };
 
     var modifiedValidator = ourModifier(customValidator);
 
-    expect(modifiedValidator('banana')).toEqual({
-      valid: true,
-      message: null
-    });
+    expect(modifiedValidator('banana')).toEqual(valid());
   });
 
   it("returns the result of the original validator when the condition is true", function() {
@@ -25,36 +21,24 @@ describe('ifOnly modifier', function() {
     var ourModifier = onlyIfModifierFactory(true);
 
     var customValidator = function(value) {
-      return {
-        valid: false,
-        message: "NICE TRY"
-      }
+      return invalid('NICE TRY');
     };
 
     var modifiedValidator = ourModifier(customValidator);
 
-    expect(modifiedValidator('banana')).toEqual({
-      valid: false,
-      message: "NICE TRY"
-    });
+    expect(modifiedValidator('banana')).toEqual(invalid('NICE TRY'));
   });
 
   it("is always valid when the function evalutes to false", function() {
     var ourModifier = onlyIfModifierFactory(function() { return false });
 
     var customValidator = function(value) {
-      return {
-        valid: false,
-        message: null
-      }
+      return invalid('nope');
     };
 
     var modifiedValidator = ourModifier(customValidator);
 
-    expect(modifiedValidator('banana')).toEqual({
-      valid: true,
-      message: null
-    });
+    expect(modifiedValidator('banana')).toEqual(valid());
   });
 
   it("returns the result of the original validator when the function evalutes to true", function() {
@@ -62,18 +46,12 @@ describe('ifOnly modifier', function() {
     var ourModifier = onlyIfModifierFactory(function() { return true; });
 
     var customValidator = function(value) {
-      return {
-        valid: false,
-        message: "NICE TRY"
-      }
+      return invalid('NICE TRY');
     };
 
     var modifiedValidator = ourModifier(customValidator);
 
-    expect(modifiedValidator('banana')).toEqual({
-      valid: false,
-      message: "NICE TRY"
-    });
+    expect(modifiedValidator('banana')).toEqual(invalid('NICE TRY'));
   });
 
 });

--- a/spec/modifiers/withMessageSpec.js
+++ b/spec/modifiers/withMessageSpec.js
@@ -1,41 +1,24 @@
 var withMessage = require('../../modifiers/withMessage');
+var valid = require('../../results/valid.js');
+var invalid = require('../../results/invalid.js');
 
 describe('withMessage modifier', function() {
 
   var niceModifier = withMessage('This has room for improvement!');
 
   function meanValidator(value) {
-    var valid = (value === 'perfect');
-    return {
-      valid: valid,
-      message: valid ? null : 'THIS IS TERRIBLE AND YOU SHOULD FEEL TERRIBLE'
-    };
+    return (value === 'perfect') ?
+      valid() :
+      invalid('THIS IS TERRIBLE AND YOU SHOULD FEEL TERRIBLE');
   }
 
   var niceValidator = niceModifier(meanValidator);
 
   it('preserves the validity of the original validation but overrides the message', function() {
+    expect(meanValidator('decent')).toEqual(invalid('THIS IS TERRIBLE AND YOU SHOULD FEEL TERRIBLE'));
+    expect(niceValidator('decent')).toEqual(invalid('This has room for improvement!'));
 
-    expect(meanValidator('decent')).toEqual({
-      valid: false,
-      message: 'THIS IS TERRIBLE AND YOU SHOULD FEEL TERRIBLE'
-    });
-
-    expect(niceValidator('decent')).toEqual({
-      valid: false,
-      message: 'This has room for improvement!'
-    });
-
-
-    expect(meanValidator('perfect')).toEqual({
-      valid: true,
-      message: null
-    });
-
-    expect(niceValidator('perfect')).toEqual({
-      valid: true,
-      message: null
-    });
-
+    expect(meanValidator('perfect')).toEqual(valid());
+    expect(niceValidator('perfect')).toEqual(valid());
   });
 });

--- a/spec/usage/usageExampleSpec.js
+++ b/spec/usage/usageExampleSpec.js
@@ -8,8 +8,8 @@ describe('Use Case #1: Validating a name for letters only pattern and length ', 
         .withMessage('Name must consist only of uppercase and lowercase letters.');
 
     var result = basicValidation.validate('Matt Rothenberg192');
-    expect(result.valid).toBeFalsy();
-    expect(result.messages).toContain('Must be exactly 10 characters.');
-    expect(result.messages).toContain('Name must consist only of uppercase and lowercase letters.');
+    expect(result.isValid()).toBeFalsy();
+    expect(result.errors).toContain('Must be exactly 10 characters.');
+    expect(result.errors).toContain('Name must consist only of uppercase and lowercase letters.');
   });
 });

--- a/spec/validators/customSpec.js
+++ b/spec/validators/customSpec.js
@@ -1,4 +1,6 @@
 var customValidator = require('../../validators/custom');
+var valid = require('../../results/valid');
+var invalid = require('../../results/invalid');
 
 describe('custom validator', function() {
   beforeEach(function() {
@@ -10,11 +12,11 @@ describe('custom validator', function() {
     }
 
     this.doesValidate = function() {
-      return this.validationResult().valid;
+      return this.validationResult().isValid();
     }
 
     this.message = function() {
-      return this.validationResult().message;
+      return this.validationResult().errors[0];
     }
   });
 
@@ -22,10 +24,9 @@ describe('custom validator', function() {
     beforeEach(function(){
       this.value = 'question';
       this.customValidator = function(value) {
-        return {
-          valid: value[0] == 'q',
-          message: value[0] == 'q' ? null : "Unacceptable!"
-        };
+        return (value[0] === 'q') ?
+          valid() :
+          invalid("Unacceptable!");
       }
     });
 

--- a/spec/validators/lengthSpec.js
+++ b/spec/validators/lengthSpec.js
@@ -10,11 +10,11 @@ describe('length validator', function() {
     }
 
     this.doesValidate = function() {
-      return this.validationResult().valid;
+      return this.validationResult().isValid();
     }
 
     this.message = function() {
-      return this.validationResult().message;
+      return this.validationResult().errors[0];
     }
   });
 
@@ -50,7 +50,7 @@ describe('length validator', function() {
 
     it('validates', function() {
       expect(this.doesValidate()).toBeTruthy();
-      expect(this.message()).toBeNull();
+      expect(this.message()).toBeUndefined();
     });
   });
 

--- a/spec/validators/patternSpec.js
+++ b/spec/validators/patternSpec.js
@@ -10,11 +10,11 @@ describe('pattern validator', function() {
     }
 
     this.doesValidate = function() {
-      return this.validationResult().valid;
+      return this.validationResult().isValid();
     }
 
     this.message = function() {
-      return this.validationResult().message;
+      return this.validationResult().errors[0];
     }
   });
 
@@ -38,7 +38,7 @@ describe('pattern validator', function() {
 
     it('validates', function() {
       expect(this.doesValidate()).toBeTruthy();
-      expect(this.message()).toBeNull();
+      expect(this.message()).toBeUndefined();
     });
   });
 

--- a/validators/length.js
+++ b/validators/length.js
@@ -1,10 +1,9 @@
+var valid = require('../results/valid');
+var invalid = require('../results/invalid');
+
 module.exports = function(requiredLength) {
   return function(value) {
-    var valid = value != null && value.length === requiredLength;
-
-    return {
-      valid: valid,
-      message: valid ? null : 'Must be exactly ' + requiredLength + ' characters.'
-    }
+    return (value != null && value.length === requiredLength) ?
+      valid() : invalid('Must be exactly ' + requiredLength + ' characters.');
   }
 };

--- a/validators/pattern.js
+++ b/validators/pattern.js
@@ -1,11 +1,11 @@
+var valid = require('../results/valid');
+var invalid = require('../results/invalid');
+
 module.exports = function(pattern) {
   return function(value) {
     if (value === null || value === undefined) { value = ''; }
-    var valid = !! value.match(pattern);
 
-    return {
-      valid: valid,
-      message: valid ? null : 'Must match pattern ' + pattern + '.'
-    };
+    return (!! value.match(pattern)) ?
+      valid() : invalid('Must match pattern ' + pattern + '.');
   };
 };


### PR DESCRIPTION
Rather than relying on individual validators to construct result
objects, this commit creates a defined Result that validators can
construct. This allows for more guidance in cases where result objects
need to be modified (either by modifiers or when aggregating the results
of multiple validators).

Possible future work: it seems like the `attributeErrors` attribute
should actually contain a map of attribute names to Result objects; this
would allow for validating objects with multiple levels of nested
attributes.